### PR TITLE
[E3-3] 实现 gpuSyncStateFromDevice()

### DIFF
--- a/src/GPU/DeviceContext.cu
+++ b/src/GPU/DeviceContext.cu
@@ -965,4 +965,18 @@ void Model_Data::gpuWaitForcingCopy()
     cudaDie(err, "gpuWaitForcingCopy(cudaEventSynchronize)");
 }
 
+void Model_Data::gpuSyncStateFromDevice(N_Vector y)
+{
+    if (y == nullptr) {
+        return;
+    }
+
+    if (N_VGetVectorID(y) != SUNDIALS_NVEC_CUDA) {
+        return;
+    }
+
+    N_VCopyFromDevice_Cuda(y);
+    (void)N_VGetHostArrayPointer_Cuda(y);
+}
+
 #endif /* _CUDA_ON */

--- a/src/Model/shud.cpp
+++ b/src/Model/shud.cpp
@@ -202,10 +202,7 @@ double SHUD(FileIn *fin, FileOut *fout){
         }
         //            CVODEstatus(mem, udata, t);
 #ifdef _CUDA_ON
-        if (N_VGetVectorID(udata) == SUNDIALS_NVEC_CUDA) {
-            /* Sync state back to host for CPU-side summary/output. */
-            N_VCopyFromDevice_Cuda(udata);
-        }
+        MD->gpuSyncStateFromDevice(udata);
 #endif
         MD->summary(udata);
         MD->CS.ExportResults(t);

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -289,6 +289,7 @@ public:
 #ifdef _CUDA_ON
     void gpuUpdateForcing();
     void gpuWaitForcingCopy();
+    void gpuSyncStateFromDevice(N_Vector y);
 #endif
     double getArea();
     void PassValue();


### PR DESCRIPTION
## Summary
Implements #11

## Changes
- 在 `Model_Data.hpp` 声明 `gpuSyncStateFromDevice(N_Vector y)` 方法
- 在 `DeviceContext.cu` 实现该方法，调用 `N_VCopyFromDevice_Cuda(y)` 同步状态
- 在 `shud.cpp` 的 `summary()` 和 `ExportResults()` 前调用
- 替换原先散落的 `N_VCopyFromDevice_Cuda(udata)` 调用

## Technical Details
- 使用 `N_VCopyFromDevice_Cuda(y)` 将 device 数据拷回 host
- 调用 `N_VGetHostArrayPointer_Cuda(y)` 确保 host 侧数据可用
- `uYsf/uYus/uYgw/uYriv/uYlake` 是独立 host 数组，无需重绑指针

## Testing
- [x] `make shud` 编译通过
- [x] CUDA 版输出格式与 CPU 版一致

Closes #11