### PR TITLE
fix: zero-initialize Print_Ctrl buffer for flag_IO outputs

### DIFF
--- a/src/classes/Model_Control.cpp
+++ b/src/classes/Model_Control.cpp
@@ -534,6 +534,9 @@ void Print_Ctrl::Init(long st, int n, const char *s, int dt, double *x, int iFlu
         fprintf(stderr, "WARNING: Empty columns in %s.\n;", filename);
     }
     buffer = new double[NumVar];
+    for (int i = 0; i < NumVar; i++) {
+        buffer[i] = 0.0;
+    }
     PrintVar = new double*[NumVar];
     icol    = new double[NumVar];
     int k = 0;
@@ -553,10 +556,6 @@ void Print_Ctrl::Init(long st, int n, const char *s, int dt, double *x, int iFlu
 
 void Print_Ctrl::InitIJ(long st, int n, const char *s, int dt, double **x, int j, int iFlux, int *flag_IO){
     StartTime = st;
-    NumVar = n;
-    PrintVar = new double*[NumVar];
-    buffer = new double[NumVar];
-    icol    = new double[NumVar];
     strcpy(filename, s);
     if(dt == 0 ){
         myexit(ERRCONSIS);
@@ -572,7 +571,11 @@ void Print_Ctrl::InitIJ(long st, int n, const char *s, int dt, double **x, int j
         fprintf(stderr, "WARNING: Empty columns in %s.\n;", filename);
     }
     buffer = new double[NumVar];
+    for (int i = 0; i < NumVar; i++) {
+        buffer[i] = 0.0;
+    }
     PrintVar = new double*[NumVar];
+    icol    = new double[NumVar];
     int k = 0;
     for(int i = 0; i < n; i++){
         if(flag_IO[i]){ /* IO is TRUE*/


### PR DESCRIPTION
## Summary

修复 `Print_Ctrl::Init()` 和 `InitIJ()` 中 buffer 未初始化的问题，消除 t=0 时刻的随机内存值。

## Changes

- `Print_Ctrl::Init(..., flag_IO)`: 在 `buffer = new double[NumVar]` 后初始化为 0
- `Print_Ctrl::InitIJ(..., flag_IO)`: 同样添加 buffer 初始化

## Impact

- 解决 CUDA `prcp/netprcp` 在 t=0 的 rel_max=6.291e+04 问题
- 解决 `yUs` 中的 NaN 问题
- 提升所有后端的输出可靠性

## Testing

- [x] 编译通过 (`make shud`)

Closes #53