### PR TITLE
fix: OpenMP race condition in f_applyDY_omp

### DIFF
--- a/src/ModelData/MD_f_omp.cpp
+++ b/src/ModelData/MD_f_omp.cpp
@@ -9,7 +9,7 @@
 void Model_Data::f_applyDY_omp(double *DY, double t){
     double area;
     int isf, ius, igw, i;
-#pragma omp parallel  default(shared) private(i) num_threads(CS.num_threads)
+#pragma omp parallel  default(shared) private(i, area, isf, ius, igw) num_threads(CS.num_threads)
     {
 #pragma omp for
         for (i = 0; i < NumEle; i++) {


### PR DESCRIPTION
## Summary

修复 `f_applyDY_omp()` 中的 OpenMP 竞态条件，将 `area/isf/ius/igw` 变量声明为 private。

## Changes

- `src/ModelData/MD_f_omp.cpp:12`: 添加 `private(i, area, isf, ius, igw)`
- 检查了 `f_loop_omp` 和 `f_update_omp`，未发现类似问题

## Impact

- 消除多线程同时写共享变量导致的 DY 写入错误
- CPU vs OMP 误差预期下降到 1e-10 量级

## Testing

- [x] 编译通过 (`make shud_omp`)
- [x] 运行验证 (`./shud_omp --help`)

Closes #54