### PR TITLE
fix: add ET and lake logic to OMP backend

### DIFF
--- a/src/ModelData/MD_ElementFlux.cpp
+++ b/src/ModelData/MD_ElementFlux.cpp
@@ -49,6 +49,9 @@ void Model_Data::fun_Ele_surface(int i, double t){
             Q = WeirFlow_jtoi(lake[ilake].zmin, nsf,
                               Ele[i].z_surf, isf,
                               Ele[i].z_surf, 0.6, B, 0.01); /* func WeirFlow_jtoi is */
+#ifdef _OPENMP_ON
+#pragma omp atomic
+#endif
             QLakeSurf[ilake] += Q;  /* Positive of QLakeSurf = Element to Lake */
 //            CheckNANi( QLakeSurf[ilake] , i, "QLakeSurf[ilake] in Model_Data::fun_Ele_surface");
         }else if (inabr >= 0) {
@@ -118,6 +121,9 @@ void Model_Data::fun_Ele_sub(int i, double t){
                 Q = Kmean * grad * Ymean * Ele[i].edge[j];
 //                CheckNANi(Q, i, "Q in Model_Data::fun_Ele_sub");
             }
+#ifdef _OPENMP_ON
+#pragma omp atomic
+#endif
             QLakeSub[ilake] += Q; /* Positive of QLakeSub = Element to Lake */
         }else if (inabr >= 0) {
             /***************************************************************************/

--- a/src/ModelData/MD_RiverFlux.cpp
+++ b/src/ModelData/MD_RiverFlux.cpp
@@ -21,6 +21,9 @@ void Model_Data::Flux_RiverDown(double t, int i){
             CSarea = Riv[i].u_CSarea;
             R = (Perem <= 0.) ? 0. : (CSarea / Perem);
             QrivDown[i] = ManningEquation(CSarea, n, R, s);
+#ifdef _OPENMP_ON
+#pragma omp atomic
+#endif
             QLakeRivIn[Riv[i].toLake] += QrivDown[i];  /* Positive = river to Lake */
     }else if (iDown >= 0) {
         sMean = (Riv[i].BedSlope + Riv[iDown].BedSlope) * 0.5 ;


### PR DESCRIPTION
## Summary

在 OMP 后端补齐与 Serial 版本等价的 ET 和湖泊处理逻辑。

## Changes

### f_loop_omp() (MD_f_omp.cpp:84)
- 非湖泊单元每步调用 `f_etFlux(i,t)`
- 湖泊单元走 `updateLakeElement()` + `fun_Ele_lakeVertical/Horizon()`
- 按 Serial 逻辑对 `qLakeEvap/qLakePrcp` 做累加与蒸发上限裁剪

### f_applyDY_omp() (MD_f_omp.cpp:9)
- 湖泊单元 `DY` 置 0
- 增加 `DY[iLAKE]` 计算

### f_update_omp() (MD_f_omp.cpp:142)
- 更新 `yLakeStg/y2LakeArea`
- RHS 前清零湖泊通量累积量

### OpenMP 并行安全
- `MD_ElementFlux.cpp:35`: `QLakeSurf/QLakeSub` atomic
- `MD_RiverFlux.cpp:5`: `QLakeRivIn` atomic
- `MD_f_omp.cpp:84`: `qLakeEvap/qLakePrcp` atomic

## Testing

- [x] 编译通过 (`make shud`, `make shud_omp`)

Closes #55