### PR TITLE
fix: align OMP river DY formula with serial

### DIFF
--- a/src/ModelData/MD_f_omp.cpp
+++ b/src/ModelData/MD_f_omp.cpp
@@ -62,7 +62,11 @@ void Model_Data::f_applyDY_omp(double *DY, double t){
                 //            Newmann condition.
                 DY[iRIV] = 0.;
             }else{
-                DY[iRIV] = (- QrivUp[i] - QrivSurf[i] - QrivSub[i] - QrivDown[i] + Riv[i].qBC) / Riv[i].u_TopArea;
+                double dA = (- QrivUp[i] - QrivSurf[i] - QrivSub[i] - QrivDown[i] + Riv[i].qBC) / Riv[i].Length; // dA on CS
+                if(dA < -1. * Riv[i].u_CSarea){ /* The negative dA cannot larger then Availalbe Area. */
+                    dA = -1. * Riv[i].u_CSarea;
+                }
+                DY[iRIV] = fun_dAtodY(dA, Riv[i].u_topWidth, Riv[i].bankslope);
             }
             //        DY[iRIV] = 0.0;
 #ifdef DEBUG


### PR DESCRIPTION
## Summary

将 OMP 河道 DY 计算公式对齐 Serial 实现。

## Changes

- 使用 `/ Riv[i].Length` 而非 `/ Riv[i].u_TopArea`
- 添加负面积限制 `if(dA < -Riv[i].u_CSarea)`
- 使用 `fun_dAtodY(&Riv[i], dA)` 转换

## Testing

- [x] 编译通过 (`make shud_omp`)

Closes #56