### PR TITLE
fix: sync GPU diagnostics D2H for correct output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,12 @@ MAIN_DEBUG 		= ${SRC_DIR}/main.cpp
 
 CC       = /usr/bin/g++
 MPICC    = /usr/local/bin/mpic++
+NVCC_DEFAULT := $(CUDA_HOME)/bin/nvcc
+ifneq ($(wildcard $(NVCC_DEFAULT)),)
+NVCC     ?= $(NVCC_DEFAULT)
+else
 NVCC     ?= nvcc
+endif
 CFLAGS   = -O3 -g  -std=c++14
 #STCFLAG     = -static
 

--- a/src/Model/shud.cpp
+++ b/src/Model/shud.cpp
@@ -212,6 +212,9 @@ double SHUD(FileIn *fin, FileOut *fout){
         //            CVODEstatus(mem, udata, t);
 #ifdef _CUDA_ON
         MD->gpuSyncStateFromDevice(udata);
+        if (N_VGetVectorID(udata) == SUNDIALS_NVEC_CUDA) {
+            MD->gpuSyncDiagnosticsFromDevice();
+        }
 #endif
         MD->summary(udata);
         MD->CS.ExportResults(t);

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -299,6 +299,7 @@ public:
     void gpuUpdateForcing();
     void gpuWaitForcingCopy();
     void gpuSyncStateFromDevice(N_Vector y);
+    void gpuSyncDiagnosticsFromDevice();
 #endif
     double getArea();
     void PassValue();


### PR DESCRIPTION
## Summary

添加 `gpuSyncDiagnosticsFromDevice()` 函数，将 GPU 计算的诊断量同步回 host 用于输出。

## Changes

### DeviceContext.cu
- 新增 `gpuSyncDiagnosticsFromDevice()` 函数
- 使用 `cudaMemcpyAsync` 拷贝以下变量:
  - Element: qEleInfil, qEleExfil, qEleRecharge, qEs, qEu, qEg, qTu, qTg
  - River: QrivSurf, QrivSub, QrivDown, QrivUp
  - Flux: QeleSurf, QeleSub (并重算 QeleSurfTot/QeleSubTot)

### shud.cpp
- 在 `CS.ExportResults()` 之前调用同步函数

### Makefile
- 自动检测 CUDA_HOME 设置 nvcc 路径

## Impact

- CPU vs CUDA 的通量/诊断文件应从 FAIL 变为 PASS
- 输出文件不再保持初值 0

## Testing

- [x] 编译通过 (`make shud_cuda`)

Closes #57