### PR TITLE
fix(bc): align uYgw semantics for iBC<0 across CPU/OMP/CUDA

### DIFF
--- a/src/GPU/rhs_kernels.cu
+++ b/src/GPU/rhs_kernels.cu
@@ -572,8 +572,10 @@ __global__ void k_apply_bc_and_sanitize_state(const realtype *dY, const DeviceMo
             const int i = idx - 2 * nEle;
             const int bc = (m->ele_iBC != nullptr) ? m->ele_iBC[i] : 0;
             if (bc > 0 && m->ele_yBC != nullptr) {
+                // iBC > 0 (Dirichlet): override yGW with prescribed head.
                 m->uYgw[i] = m->ele_yBC[i];
             } else {
+                // iBC <= 0 (no BC or fixed-flux/Neumann): yGW remains a state variable (dY); flux is applied in DYgw.
                 m->uYgw[i] = clamp_policy ? d_clamp_nonneg(y) : y;
             }
         } else if (idx < 3 * nEle + nRiv) {

--- a/src/ModelData/MD_f_omp.cpp
+++ b/src/ModelData/MD_f_omp.cpp
@@ -165,7 +165,8 @@ void Model_Data::f_update_omp(double  *Y, double *DY, double t){
                 Ele[i].yBC = tsd_eyBC.getX(t, Ele[i].iBC);
                 uYgw[i] = Ele[i].yBC;
                 Ele[i].QBC = 0.;
-            }else{ // BC fix flux to GW
+            }else{ // BC fix flux to GW: uYgw remains a state variable (Y[iGW]); flux is applied in DYgw.
+                uYgw[i] = CLAMP_POLICY ? max(0.0, Y[iGW]) : Y[iGW];
                 Ele[i].QBC = tsd_eqBC.getX(t, -Ele[i].iBC);
             }
             /***** SS and BC *****/

--- a/src/ModelData/MD_update.cpp
+++ b/src/ModelData/MD_update.cpp
@@ -88,7 +88,8 @@ void Model_Data::f_updatei(double  *Y, double *DY, double t, int flag){
                     Ele[i].yBC = tsd_eyBC.getX(t, Ele[i].iBC);
                     uYgw[i] = Ele[i].yBC;
                     Ele[i].QBC = 0.;
-                }else{ // BC fix flux to GW
+                }else{ // BC fix flux to GW: uYgw remains a state variable (Y); flux is applied in DYgw.
+                    uYgw[i] = CLAMP_POLICY ? max(0.0, Y[i]) : Y[i];
                     Ele[i].QBC = tsd_eqBC.getX(t, -Ele[i].iBC);
                 }
             }
@@ -142,7 +143,8 @@ void Model_Data::f_update(double  *Y, double *DY, double t){
             Ele[i].yBC = tsd_eyBC.getX(t, Ele[i].iBC);
             uYgw[i] = Ele[i].yBC;
             Ele[i].QBC = 0.;
-        }else{ // BC fix flux to GW
+        }else{ // BC fix flux to GW: uYgw remains a state variable (Y[iGW]); flux is applied in DYgw.
+            uYgw[i] = CLAMP_POLICY ? max(0.0, Y[iGW]) : Y[iGW];
             Ele[i].QBC = tsd_eqBC.getX(t, -Ele[i].iBC);
         }
         qEleExfil[i] = 0.;


### PR DESCRIPTION
## Summary
Implements #65 - 明确并对齐 iBC<0（GW 固定通量 BC）的 uYgw 语义

## Changes
- CPU: 在 `iBC < 0` 分支显式设置 `uYgw = Y`（`src/ModelData/MD_update.cpp`）
- OMP: 同样在 `iBC < 0` 分支补齐 `uYgw = Y`（`src/ModelData/MD_f_omp.cpp`）
- CUDA: 原实现已符合语义，补充注释说明（`src/GPU/rhs_kernels.cu`）

## Semantic Clarification
`iBC < 0`（GW 固定通量/Neumann）时：
- `uYgw`/`yGW` 仍由状态向量 `Y` 决定（按 `CLAMP_POLICY` clamp）
- 仅在 `DYgw` 中通过 `QBC/area` 施加通量项

## Testing
- [x] `make shud` 编译通过
- [x] `make shud_omp` 编译通过
- [x] `make shud_cuda` 编译通过

Closes #65