### PR TITLE
feat(cuda): add runtime toggle for preconditioner

### DIFF
--- a/src/Equations/cvode_config.cpp
+++ b/src/Equations/cvode_config.cpp
@@ -173,6 +173,10 @@ void SetCVODE(void * &cvode_mem, CVRhsFn f, Model_Data *MD,  N_Vector udata, SUN
     flag = CVodeSStolerances(cvode_mem, MD->CS.reltol, MD->CS.abstol);
     check_flag(&flag, "CVodeSStolerances", 1);
     
+    /* CUDA preconditioner toggle (default ON for CUDA backend).
+     * - CLI: --precond / --no-precond
+     * - Env: SHUD_CUDA_PRECOND=0/1
+     */
     const bool use_cuda_precond =
 #ifdef _CUDA_ON
         (global_backend == BACKEND_CUDA && global_precond_enabled &&

--- a/src/GPU/precond_kernels.cu
+++ b/src/GPU/precond_kernels.cu
@@ -206,8 +206,13 @@ __device__ inline void element_local_rhs(const DeviceModel *m,
         satKr = satKfun(satn_new, Beta);
     }
 
-    /* f_etFlux */
-    const double iBeta = soilMoistureStress(ThetaS, ThetaR, satn_new);
+    /* f_etFlux (match RHS behavior: use satn from previous RHS evaluation). */
+    double satn_prev = (m->ele_satn != nullptr) ? m->ele_satn[i] : -1.0;
+    const bool satn_prev_valid = (satn_prev == satn_prev) && satn_prev >= 0.0 && satn_prev <= 1.0;
+    if (!satn_prev_valid) {
+        satn_prev = satn_new;
+    }
+    const double iBeta = soilMoistureStress(ThetaS, ThetaR, satn_prev);
     const double va = VegFrac;
     const double vb = 1.0 - VegFrac;
     const double pj = 1.0 - ImpAF;

--- a/src/classes/CommandIn.cpp
+++ b/src/classes/CommandIn.cpp
@@ -24,6 +24,7 @@ void CommandIn::SHUD_help(const char *prog){
     printf ("          Default depends on binary: shud→cpu, shud_omp→omp, shud_cuda→cuda.\n");
     printf (" --precond Enable CVODE preconditioner (CUDA backend only; default ON for --backend cuda).\n");
     printf (" --no-precond Disable CVODE preconditioner.\n");
+    printf ("          Env override: SHUD_CUDA_PRECOND=0 disables, =1 enables (default 1).\n");
     printf (" --help Print this message and exit.\n");
 }
 


### PR DESCRIPTION
## Summary
Implements #66 - 评估预条件器对精度的影响（提供可开关对比）

## Changes
1. **预条件器运行时开关** (`src/Model/shud.cpp`, `src/Equations/cvode_config.cpp`)
   - 环境变量 `SHUD_CUDA_PRECOND`（默认 ON）
   - CLI 参数 `--precond` / `--no-precond`
   - 启动时打印当前状态

2. **修正预条件器 ET 一致性** (`src/GPU/precond_kernels.cu`)
   - `iBeta` 改为优先用 `ele_satn`（与 RHS 一致）
   - 无效时回退 `satn_new`

## Usage
```bash
# 关闭预条件器（等价于 CPU/OMP 的 PREC_NONE）
SHUD_CUDA_PRECOND=0 ./shud_cuda ccw
# 或
./shud_cuda --no-precond ccw

# 开启预条件器（默认）
./shud_cuda ccw
```

## Testing
- [x] `make shud_cuda` 编译通过

Closes #66