### PR TITLE
[P2] PERF-IO-001: output groups + IO-off mode

### DIFF
--- a/src/Model/Macros.hpp
+++ b/src/Model/Macros.hpp
@@ -168,6 +168,15 @@ enum Backend { BACKEND_CPU = 0, BACKEND_OMP = 1, BACKEND_CUDA = 2 };
 extern int global_backend;
 /* Whether --backend was explicitly set by CLI. */
 extern int global_backend_cli_set;
+
+enum OutputGroupMask {
+    OUTPUT_GROUP_STATE = 1 << 0,
+    OUTPUT_GROUP_FLUX = 1 << 1,
+    OUTPUT_GROUP_DIAG = 1 << 2,
+    OUTPUT_GROUP_ALL = OUTPUT_GROUP_STATE | OUTPUT_GROUP_FLUX | OUTPUT_GROUP_DIAG,
+};
+/* Runtime output group selection (bitmask of OutputGroupMask). */
+extern int global_output_groups;
 /* ClampPolicy: whether to clamp state variables to non-negative values before flux computation.
  * 1 (default): clamp enabled. 0: clamp disabled (legacy serial behavior).
  *

--- a/src/ModelData/MD_initialize.cpp
+++ b/src/ModelData/MD_initialize.cpp
@@ -241,91 +241,102 @@ void Model_Data::initialize(){
 }
 void Model_Data:: initialize_output (){
     int ip = 0;
+    const bool out_state = (global_output_groups & OUTPUT_GROUP_STATE) != 0;
+    const bool out_flux = (global_output_groups & OUTPUT_GROUP_FLUX) != 0;
+    const bool out_diag = (global_output_groups & OUTPUT_GROUP_DIAG) != 0;
     /* Storage */
-    if (CS.dt_ye_ic > 0)
+    if (out_state && CS.dt_ye_ic > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_y_ic, CS.dt_ye_ic,yEleIS, 0, io_ele);
-    if (CS.dt_ye_snow > 0)
+    if (out_state && CS.dt_ye_snow > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_y_snow, CS.dt_ye_snow, yEleSnow, 0, io_ele);
-    if (CS.dt_ye_surf > 0)
+    if (out_state && CS.dt_ye_surf > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_y_surf, CS.dt_ye_surf, yEleSurf, 0, io_ele);
-    if (CS.dt_ye_unsat > 0)
+    if (out_state && CS.dt_ye_unsat > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_y_unsat, CS.dt_ye_unsat, yEleUnsat, 0, io_ele);
     
-    if (CS.dt_ye_gw > 0)
+    if (out_state && CS.dt_ye_gw > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_y_gw, CS.dt_ye_gw, yEleGW, 0, io_ele);
     /* Fluxes */
-    if (CS.dt_qe_prcp > 0)
+    if (out_flux && CS.dt_qe_prcp > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_prcp, CS.dt_qe_prcp, qElePrep, 1, io_ele);
-    if (CS.dt_qe_prcp > 0)
+    if (out_flux && CS.dt_qe_prcp > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_netprcp, CS.dt_qe_prcp, qEleNetPrep, 1, io_ele);
-    if (CS.dt_qe_etp > 0)
+    if (out_flux && CS.dt_qe_etp > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ETP, CS.dt_qe_etp, qEleETP, 1, io_ele);
-    if (CS.dt_qe_eta > 0)
+    if (out_flux && CS.dt_qe_eta > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ETA, CS.dt_qe_eta, qEleETA, 1, io_ele);
-    if (CS.dt_qe_rech > 0)
+    if (out_flux && CS.dt_qe_rech > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_rech, CS.dt_qe_rech, qEleRecharge, 1, io_ele);
-    if (CS.dt_Qe_sub > 0){
+    if (out_flux && CS.dt_Qe_sub > 0){
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_Q_subTot, CS.dt_Qe_sub, QeleSubTot, 1, io_ele);
     }
-    if (CS.dt_Qe_subx > 0){
+    if (out_flux && CS.dt_Qe_subx > 0){
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_sub0, CS.dt_Qe_sub, QeleSub, 0, 1, io_ele);
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_sub1, CS.dt_Qe_sub, QeleSub, 1, 1, io_ele);
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_sub2, CS.dt_Qe_sub, QeleSub, 2, 1, io_ele);
     }
-    if (CS.dt_Qe_surf > 0){
+    if (out_flux && CS.dt_Qe_surf > 0){
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_Q_surfTot, CS.dt_Qe_surf, QeleSurfTot, 1, io_ele);
     }
-    if (CS.dt_Qe_surfx > 0){
+    if (out_flux && CS.dt_Qe_surfx > 0){
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_surf0, CS.dt_Qe_surf, QeleSurf, 0, 1, io_ele);
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_surf1, CS.dt_Qe_surf, QeleSurf, 1, 1, io_ele);
         CS.PCtrl[ip++].InitIJ(ForcStartTime, NumEle, pf_out->ele_Q_surf2, CS.dt_Qe_surf, QeleSurf, 2, 1, io_ele);
     }
-    if (CS.dt_Qe_rsub > 0){
+    if (out_flux && CS.dt_Qe_rsub > 0){
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_Q_rsub, CS.dt_Qe_rsub, Qe2r_Sub, 1, io_ele);
     }
-    if (CS.dt_Qe_rsurf > 0){
+    if (out_flux && CS.dt_Qe_rsurf > 0){
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_Q_rsurf, CS.dt_Qe_rsurf, Qe2r_Surf, 1, io_ele);
     }
-    if (CS.dt_qe_infil > 0){
+    if (out_flux && CS.dt_qe_infil > 0){
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_infil, CS.dt_qe_infil, qEleInfil, 1, io_ele);
         CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_exfil, CS.dt_qe_infil, qEleExfil, 1, io_ele);
     }
     
     /* ET  2d array */
     if (CS.dt_qe_et > 0){
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[0], CS.dt_qe_et, qEleE_IC, 1, io_ele);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[1], CS.dt_qe_et, qEleTrans, 1, io_ele);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[2], CS.dt_qe_et, qEleEvapo, 1, io_ele);
+        if (out_flux) {
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[0], CS.dt_qe_et, qEleE_IC, 1, io_ele);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[1], CS.dt_qe_et, qEleTrans, 1, io_ele);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->ele_q_ET[2], CS.dt_qe_et, qEleEvapo, 1, io_ele);
+        }
 
-        /* TSR debug outputs (instantaneous, averaged over the output interval) */
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_h, CS.dt_qe_et, ele_rn_h_wm2, 0, io_ele);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_t, CS.dt_qe_et, ele_rn_t_wm2, 0, io_ele);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_factor, CS.dt_qe_et, ele_rn_factor, 0, io_ele);
+        if (out_diag) {
+            /* TSR debug outputs (instantaneous, averaged over the output interval) */
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_h, CS.dt_qe_et, ele_rn_h_wm2, 0, io_ele);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_t, CS.dt_qe_et, ele_rn_t_wm2, 0, io_ele);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumEle, pf_out->file_ele_rn_factor, CS.dt_qe_et, ele_rn_factor, 0, io_ele);
+        }
     }
     
     
     /* Print control for River */
-    if (CS.dt_Qr_up > 0)
+    if (out_flux && CS.dt_Qr_up > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumRiv, pf_out->riv_Q_up, CS.dt_Qr_up, QrivUp, 1, io_riv);
-    if (CS.dt_Qr_down > 0)
+    if (out_flux && CS.dt_Qr_down > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumRiv, pf_out->riv_Q_down, CS.dt_Qr_down, QrivDown, 1, io_riv);
-    if (CS.dt_Qr_sub > 0)
+    if (out_flux && CS.dt_Qr_sub > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumRiv, pf_out->riv_Q_sub, CS.dt_Qr_sub, QrivSub, 1, io_riv);
-    if (CS.dt_Qr_surf > 0)
+    if (out_flux && CS.dt_Qr_surf > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumRiv, pf_out->riv_Q_surf, CS.dt_Qr_surf, QrivSurf, 1, io_riv);
-    if (CS.dt_yr_stage > 0)
+    if (out_state && CS.dt_yr_stage > 0)
         CS.PCtrl[ip++].Init(ForcStartTime, NumRiv, pf_out->riv_y_stage, CS.dt_yr_stage, yRivStg, 0, io_riv);
     
     /* Print control for Lake */
     if (CS.dt_lake > 0 && NumLake > 0){
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_y_stage, CS.dt_lake, yLakeStg, 0, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_a_area, CS.dt_lake, y2LakeArea, 0, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_q_evap, CS.dt_lake, qLakeEvap, 1, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_q_prcp, CS.dt_lake, qLakePrcp, 1, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_rivin, CS.dt_lake, QLakeRivIn, 1, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_rivout, CS.dt_lake, QLakeRivOut, 1, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_surf, CS.dt_lake, QLakeSurf, 1, io_lake);
-        CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_sub, CS.dt_lake, QLakeSub, 1, io_lake);
+        if (out_state) {
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_y_stage, CS.dt_lake, yLakeStg, 0, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_a_area, CS.dt_lake, y2LakeArea, 0, io_lake);
+        }
+        if (out_flux) {
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_q_evap, CS.dt_lake, qLakeEvap, 1, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_q_prcp, CS.dt_lake, qLakePrcp, 1, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_rivin, CS.dt_lake, QLakeRivIn, 1, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_rivout, CS.dt_lake, QLakeRivOut, 1, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_surf, CS.dt_lake, QLakeSurf, 1, io_lake);
+            CS.PCtrl[ip++].Init(ForcStartTime, NumLake, pf_out->lake_Q_sub, CS.dt_lake, QLakeSub, 1, io_lake);
+        }
     }
     CS.NumPrint = ip;
     

--- a/src/ModelData/MD_readin.cpp
+++ b/src/ModelData/MD_readin.cpp
@@ -785,9 +785,18 @@ void Model_Data::FreeData(){
         delete[] QeleSub[i] ;
     }
     
-    delete[]    io_ele;
-    delete[]    io_riv;
-    delete[]    io_lake;
+    if (io_ele != NULL) {
+        delete[] io_ele;
+        io_ele = NULL;
+    }
+    if (io_riv != NULL) {
+        delete[] io_riv;
+        io_riv = NULL;
+    }
+    if (io_lake != NULL) {
+        delete[] io_lake;
+        io_lake = NULL;
+    }
     
     delete[]    QeleSurf;
     delete[]    QeleSub;

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -75,7 +75,9 @@ public:
     int NumMeltF = 0;        /* Number of Melt Factor Time series */
     int NumRivType = 0;        /* Number of River Shape */
     int NumRivNode = 0;
-    int *io_ele, *io_riv, *io_lake; /* Wether Export the data of these elements */
+    int *io_ele = NULL;
+    int *io_riv = NULL;
+    int *io_lake = NULL; /* Whether export the data of these elements */
     
     _TimeSeriesData *tsd_weather;
     _TimeSeriesData tsd_LAI;

--- a/src/classes/FloodAlert.cpp
+++ b/src/classes/FloodAlert.cpp
@@ -34,8 +34,11 @@ FloodAlert::~FloodAlert(){
 //    delete[]  Q_low;
 //    delete[]  Y_high;
 //    delete[]  Y_low;
-    
-    fclose(fid);
+
+    if (fid != NULL) {
+        fclose(fid);
+        fid = NULL;
+    }
 }
 void FloodAlert::pushRiverType(int index, int type){
     itype[index] = type - 1;
@@ -69,10 +72,16 @@ void FloodAlert::InitFile(const char *fn){
 }
 
 int FloodAlert::FloodWarning(double t){
+    if (fid == NULL) {
+        return 0;
+    }
     return FloodWarning(t, fid);
 }
 inline  int FloodAlert::FloodWarning(double t, FILE *fp){
     /*If there is flood, print warning. return 1 - flood, 0 - no flood*/
+    if (fp == NULL || pstage == NULL || pflux == NULL || para == NULL || itype == NULL) {
+        return 0;
+    }
     int flag = 0;
     for(int i = 0; i < nriv; i++){
         if( *(pstage[i]) > para[ itype[i] ].depth ){
@@ -85,4 +94,3 @@ inline  int FloodAlert::FloodWarning(double t, FILE *fp){
     }
     return flag;
 }
-

--- a/src/classes/FloodAlert.hpp
+++ b/src/classes/FloodAlert.hpp
@@ -27,7 +27,7 @@ public:
 private:
     int nriv = 0;;   /* Number of rivers */
     int ntype = 0;  /* Type of rivers */
-    int *itype; /* Index of rivertype for each river*/
+    int *itype = NULL; /* Index of rivertype for each river*/
     double **pstage = NULL; /* Pointers to river stage*/
     double **pflux = NULL; /* Pointers to river flux*/
     
@@ -38,7 +38,7 @@ private:
 //    double *Q_low;  /* */
 //    double *Y_high; /* */
 //    double *Y_low;  /* */
-    FILE *fid;
+    FILE *fid = NULL;
     
 };
 #endif /* FloodAlert_hpp */

--- a/src/classes/Model_Control.cpp
+++ b/src/classes/Model_Control.cpp
@@ -395,7 +395,24 @@ void Control_Data::write(const char *fn){
 void Control_Data::getValue(const char *varname){
     
 }
-Print_Ctrl::Print_Ctrl(){}
+Print_Ctrl::Print_Ctrl(){
+    NumVar = 0;
+    Interval = 0;
+    NumUpdate = 0;
+    StartTime = 0;
+    tau = 1.0;
+    Ascii = 0;
+    Binary = 0;
+    fid_bin = NULL;
+    fid_asc = NULL;
+    PrintVar = NULL;
+    buffer = NULL;
+    icol = NULL;
+    filename[0] = '\0';
+    filea[0] = '\0';
+    fileb[0] = '\0';
+    header[0] = '\0';
+}
 void Print_Ctrl::setHeader(const char *s){
     strcpy(header, s);
 }


### PR DESCRIPTION
## Summary
Implements output-group switching and a true IO-off mode for benchmarking.

## Changes
- Add `--io` flag (`all|off|state,flux,diag`) to select output groups.
- Skip heavy diag writes (Init update, flood, debug tables) when diag group is off.
- Make Print_Ctrl / FloodAlert / IO arrays safe when outputs are disabled.
- Extend bench runner to pass `--io` and record `io_groups`.

## Testing
- `make shud`
- `make shud_omp`
- `./shud -0 --io off -o output/ccw_short_off.out ccw_short` (short 2-day copy)

Closes #84