### PR TITLE
[P1] ACC-CUDA-003 Deterministic segment reductions (no atomicAdd hotspots)

### DIFF
--- a/src/GPU/DeviceContext.hpp
+++ b/src/GPU/DeviceContext.hpp
@@ -78,6 +78,12 @@ struct DeviceModel {
     double *seg_Cwr = nullptr;
     double *seg_KsatH = nullptr;
     double *seg_eqDistance = nullptr;
+    int *seg_order_by_riv = nullptr; /* [NumSeg] (sorted segment indices) */
+    int *seg_order_by_ele = nullptr; /* [NumSeg] (sorted segment indices) */
+    int *riv_seg_off = nullptr;      /* [NumRiv + 1] */
+    int *ele_seg_off = nullptr;      /* [NumEle + 1] */
+    double *seg_Qsurf = nullptr;     /* [NumSeg] */
+    double *seg_Qsub = nullptr;      /* [NumSeg] */
 
     /* Lake parameters */
     double *lake_zmin = nullptr;


### PR DESCRIPTION
Closes #81\n\n## Summary\n- Replace k_seg_exchange atomicAdd accumulation with deterministic 2-stage pipeline:\n  - k_seg_exchange_compute writes per-segment Qsurf/Qsub\n  - k_seg_reduce reduces in fixed order to QrivSurf/QrivSub and Qe2r_Surf/Qe2r_Sub\n- Add river/element→segment CSR-style mappings (seg_order_by_riv/ele + offsets) built once in gpuInit\n\n## Notes\n- Designed to reduce atomic contention and make sums deterministic (fixed reduction order per block).\n\n## Testing\n- CPU/OMP builds unaffected (CUDA-only changes).\n