### PR TITLE
[P2] PERF-CUDA-003 Pin forcing buffers + remove per-step BC allocations

### DIFF
--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -236,6 +236,10 @@ public:
     int rhs_graph_failed = 0;
     std::vector<double> d2h_QeleSurf_flat;
     std::vector<double> d2h_QeleSub_flat;
+    std::vector<double> h2d_ele_yBC;
+    std::vector<double> h2d_ele_QBC;
+    std::vector<double> h2d_riv_yBC;
+    std::vector<double> h2d_riv_qBC;
     std::vector<void *> pinned_host_buffers;
 #endif
 	    


### PR DESCRIPTION
Closes #85\n\n## Summary\n- Pin forcing input buffers (qElePrep/qEleNetPrep/qPotEvap/qPotTran/qEleE_IC/fu_*) for async H2D\n- Allocate + pin persistent host staging buffers for ele/riv BC arrays (yBC/QBC) and reuse in gpuUpdateForcing\n- Lazily pin private t_lai buffer on first gpuUpdateForcing call\n\n## Notes\n- Reduces per-forcing-step allocations and speeds up forcing H2D copy path; sync points are still coordinated via forcing_copy_event.\n\n## Testing\n- CUDA-only changes; CPU/OMP builds unaffected.\n