### PR TITLE
[P2] ACC-CUDA-005 Strict mode: deterministic reduce + strict-fp build switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,15 @@ ifeq ($(DEBUG_GPU_VERIFY),1)
   CFLAGS += -DDEBUG_GPU_VERIFY
 endif
 
+# Optional strict floating-point for CUDA build (disables FMA; enforces precise div/sqrt).
+# Enable with:
+#   make shud_cuda STRICT_FP=1
+STRICT_FP ?= 0
+NVCCFLAGS = $(CFLAGS)
+ifeq ($(STRICT_FP),1)
+  NVCCFLAGS += --fmad=false --prec-div=true --prec-sqrt=true -DSHUD_STRICT_FP_BUILD
+endif
+
 SRC    	= ${SRC_DIR}/classes/*.cpp \
 		  ${SRC_DIR}/ModelData/*.cpp \
 		  ${SRC_DIR}/Model/*.cpp \
@@ -178,10 +187,10 @@ shud_omp: ${MAIN_OMP}  $(SRC) $(SRC_H)
 
 shud_cuda: ${MAIN_shud} $(SRC) $(SRC_H) $(CUDA_SRC)
 	@echo '...Compiling shud_CUDA (NVECTOR_CUDA) ...'
-	@echo $(NVCC) $(CFLAGS) ${STCFLAG} $(CUDA_GENCODE) -D_CUDA_ON ${INCLUDES} -I ${INC_CUDA} ${LIBRARIES} -L ${LIB_CUDA} ${RPATH_CUDA} -o ${TARGET_CUDA} ${MAIN_shud} $(SRC) $(CUDA_SRC) $(LK_CUDA)
+	@echo $(NVCC) $(NVCCFLAGS) ${STCFLAG} $(CUDA_GENCODE) -D_CUDA_ON ${INCLUDES} -I ${INC_CUDA} ${LIBRARIES} -L ${LIB_CUDA} ${RPATH_CUDA} -o ${TARGET_CUDA} ${MAIN_shud} $(SRC) $(CUDA_SRC) $(LK_CUDA)
 	@echo
 	@echo
-	$(NVCC) $(CFLAGS) ${STCFLAG} $(CUDA_GENCODE) -D_CUDA_ON ${INCLUDES} -I ${INC_CUDA} ${LIBRARIES} -L ${LIB_CUDA} ${RPATH_CUDA} -o ${TARGET_CUDA} ${MAIN_shud} $(SRC) $(CUDA_SRC) $(LK_CUDA)
+	$(NVCC) $(NVCCFLAGS) ${STCFLAG} $(CUDA_GENCODE) -D_CUDA_ON ${INCLUDES} -I ${INC_CUDA} ${LIBRARIES} -L ${LIB_CUDA} ${RPATH_CUDA} -o ${TARGET_CUDA} ${MAIN_shud} $(SRC) $(CUDA_SRC) $(LK_CUDA)
 	@echo
 	@echo " ${TARGET_CUDA} is compiled successfully!"
 	@echo

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ make shud_cuda CUDA_GENCODE='-gencode arch=compute_80,code=sm_80'
 
 - `--backend cpu|omp|cuda`: select runtime backend. Each binary has its own default: `shud`→cpu, `shud_omp`→omp, `shud_cuda`→cuda. Use this flag to override.
 - `--precond` / `--no-precond`: enable/disable CVODE preconditioner (CUDA backend only; default ON for `--backend cuda`)
+  - Env override: `SHUD_CUDA_PRECOND=0/1/auto`
+- CUDA perf/consistency knobs (env vars; CUDA backend only):
+  - `SHUD_CUDA_GRAPH=0/1/auto` (+ `NY_CUDA_GRAPH_MAX` for auto threshold)
+  - `SHUD_DETERMINISTIC_REDUCE=0/1`
+  - `SHUD_STRICT_FP=0/1` (for full strict-FP, rebuild with `make shud_cuda STRICT_FP=1`)
+  - Details: `docs/cuda_strict_mode.md`
 
 Examples:
 

--- a/docs/cuda_strict_mode.md
+++ b/docs/cuda_strict_mode.md
@@ -1,0 +1,54 @@
+# CUDA strict mode (deterministic reduce / strict FP)
+
+This repo supports a “strict(er) reproducibility” configuration for the CUDA backend, aimed at improving CPU↔CUDA consistency when you need tighter tolerances (e.g. `rel_max <= 1e-6`).
+
+## Runtime switches
+
+- `SHUD_DETERMINISTIC_REDUCE=1` (default: `1`)
+  - Enables deterministic reductions for key CUDA hotspots (notably river/segment aggregation).
+  - When set to `0`, the CUDA backend falls back to the legacy `atomicAdd` accumulation path (faster on some GPUs/cases, but non-deterministic and often slower under contention).
+
+- `SHUD_STRICT_FP=1` (default: `0`)
+  - Requests strict floating-point behavior for CUDA runs.
+  - At runtime, this also forces `SHUD_DETERMINISTIC_REDUCE=1`.
+  - **Note:** disabling FMA reliably requires a strict build (see below). If `SHUD_STRICT_FP=1` is set on a non-strict build, SHUD prints a warning and continues.
+
+## Build switch (recommended for real strict-FP)
+
+Rebuild the CUDA binary with strict FP flags:
+
+```bash
+make shud_cuda STRICT_FP=1
+```
+
+This adds NVCC flags:
+- `--fmad=false` (disable fused multiply-add contraction)
+- `--prec-div=true --prec-sqrt=true` (force precise div/sqrt)
+- `-DSHUD_STRICT_FP_BUILD` (lets the binary report whether it was built in strict mode)
+
+## Performance notes
+
+- Deterministic reductions may add extra kernel(s) compared to the all-atomic path, but often reduce overall time by avoiding heavy `atomicAdd` contention.
+- Disabling FMA can noticeably slow down double-precision code. If you enable strict FP, consider also enabling CUDA Graph capture for small problems to reduce launch overhead:
+  - `SHUD_CUDA_GRAPH=auto|1` (see `README.md` / `BENCH_STATS` output).
+
+## How to evaluate accuracy
+
+On a CUDA machine:
+
+```bash
+make clean && make shud && make shud_omp && make shud_cuda
+
+# Baseline CUDA
+./shud_cuda ccw
+
+# Strict configuration
+SHUD_STRICT_FP=1 SHUD_DETERMINISTIC_REDUCE=1 ./shud_cuda ccw
+
+python3 post_analysis/accuracy_comparison.py \
+  output/ccw_cpu output/ccw_cuda \
+  --tol_cuda 1e-6
+```
+
+If `rel_max<=1e-6` is still not achievable on `ccw`, prefer documenting a per-file tolerance (or focusing on key state variables) and include CVODE stats (`CVODE_STATS` line) so “accuracy improvements” are not just a solver-path change.
+

--- a/scripts/bench/run_bench.sh
+++ b/scripts/bench/run_bench.sh
@@ -190,8 +190,11 @@ run_one() {
   rhs_launch_us="$(extract_kv rhs_launch_us "${bench_stats_line}")"
   rhs_graph="$(extract_kv rhs_graph "${bench_stats_line}")"
   cuda_graph_mode="$(extract_kv cuda_graph_mode "${bench_stats_line}")"
+  local strict_fp det_reduce
+  strict_fp="$(extract_kv strict_fp "${bench_stats_line}")"
+  det_reduce="$(extract_kv det_reduce "${bench_stats_line}")"
 
-  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
     "${backend}" \
     "${run_idx}" \
     "${wall_s}" \
@@ -204,6 +207,8 @@ run_one() {
     "${rhs_launch_us}" \
     "${rhs_graph}" \
     "${cuda_graph_mode}" \
+    "${strict_fp}" \
+    "${det_reduce}" \
     "${nfe}" \
     "${nli}" \
     "${nni}" \
@@ -226,7 +231,7 @@ mkdir -p "${OUT_DIR}/${PROJECT}"
 BENCH_LOG="${OUT_DIR}/${PROJECT}/bench.log"
 SUMMARY_MD="${OUT_DIR}/${PROJECT}/bench_summary.md"
 
-printf "backend\trun\twall_s\trun_wall_s\tcvode_s\tio_s\tforcing_s\trhs_calls\trhs_kernels\trhs_launch_us\trhs_graph\tcuda_graph_mode\tnfe\tnli\tnni\tnetf\tnpe\tnps\tio_groups\tcuda_precond\tlog\n" >"${BENCH_LOG}"
+printf "backend\trun\twall_s\trun_wall_s\tcvode_s\tio_s\tforcing_s\trhs_calls\trhs_kernels\trhs_launch_us\trhs_graph\tcuda_graph_mode\tstrict_fp\tdet_reduce\tnfe\tnli\tnni\tnetf\tnpe\tnps\tio_groups\tcuda_precond\tlog\n" >"${BENCH_LOG}"
 
 for backend in "${BACKENDS[@]}"; do
   bin=""

--- a/src/GPU/DeviceContext.cu
+++ b/src/GPU/DeviceContext.cu
@@ -298,6 +298,8 @@ void gpuInit(Model_Data *md)
     md->rhs_graph_failed = 0;
     md->rhs_graph_kernel_nodes = 0;
     md->rhs_graph_clamp_policy = 0;
+    md->rhs_graph_deterministic_reduce = 0;
+    md->rhs_graph_strict_fp = 0;
     md->rhs_graph_dY = nullptr;
     md->rhs_graph_dYdot = nullptr;
     if (md->rhs_graph_exec != nullptr) {
@@ -1373,6 +1375,8 @@ void gpuFree(Model_Data *md)
     }
     md->rhs_graph_dY = nullptr;
     md->rhs_graph_dYdot = nullptr;
+    md->rhs_graph_deterministic_reduce = 0;
+    md->rhs_graph_strict_fp = 0;
     md->rhs_graph_kernel_nodes = 0;
     md->rhs_graph_failed = 0;
 

--- a/src/GPU/f_cuda.cpp
+++ b/src/GPU/f_cuda.cpp
@@ -65,6 +65,8 @@ void destroyRhsGraph(Model_Data *md)
     md->rhs_graph_dY = nullptr;
     md->rhs_graph_dYdot = nullptr;
     md->rhs_graph_clamp_policy = 0;
+    md->rhs_graph_deterministic_reduce = 0;
+    md->rhs_graph_strict_fp = 0;
     md->rhs_graph_kernel_nodes = 0;
 }
 
@@ -127,6 +129,8 @@ bool captureRhsGraph(Model_Data *md, const realtype *dY, realtype *dYdot, cudaSt
     md->rhs_graph_dY = dY;
     md->rhs_graph_dYdot = dYdot;
     md->rhs_graph_clamp_policy = CLAMP_POLICY;
+    md->rhs_graph_deterministic_reduce = global_deterministic_reduce;
+    md->rhs_graph_strict_fp = global_strict_fp;
     md->rhs_graph_kernel_nodes = stats.kernel_nodes;
     return true;
 }
@@ -340,7 +344,9 @@ int f_gpu(double t, N_Vector y, N_Vector ydot, void *user_data)
     RhsLaunchStats rhs_stats{};
     bool use_graph = shouldUseCudaGraph(md, verify_ptr);
     if (use_graph && (md->rhs_graph_exec == nullptr || md->rhs_graph_dY != dY || md->rhs_graph_dYdot != dYdot ||
-                      md->rhs_graph_clamp_policy != CLAMP_POLICY)) {
+                      md->rhs_graph_clamp_policy != CLAMP_POLICY ||
+                      md->rhs_graph_deterministic_reduce != global_deterministic_reduce ||
+                      md->rhs_graph_strict_fp != global_strict_fp)) {
         (void)captureRhsGraph(md, dY, dYdot, rhs_stream);
     }
 
@@ -366,7 +372,9 @@ int f_gpu(double t, N_Vector y, N_Vector ydot, void *user_data)
     RhsLaunchStats rhs_stats{};
     bool use_graph = shouldUseCudaGraph(md);
     if (use_graph && (md->rhs_graph_exec == nullptr || md->rhs_graph_dY != dY || md->rhs_graph_dYdot != dYdot ||
-                      md->rhs_graph_clamp_policy != CLAMP_POLICY)) {
+                      md->rhs_graph_clamp_policy != CLAMP_POLICY ||
+                      md->rhs_graph_deterministic_reduce != global_deterministic_reduce ||
+                      md->rhs_graph_strict_fp != global_strict_fp)) {
         (void)captureRhsGraph(md, dY, dYdot, rhs_stream);
     }
 

--- a/src/Model/Macros.hpp
+++ b/src/Model/Macros.hpp
@@ -170,6 +170,10 @@ extern int global_cuda_graph_mode;
 /* Auto mode: enable graph when NumY <= global_cuda_graph_max_ny. */
 extern int global_cuda_graph_max_ny;
 
+/* Strict FP / deterministic reduction toggles (CUDA backend only). */
+extern int global_strict_fp;
+extern int global_deterministic_reduce;
+
 enum Backend { BACKEND_CPU = 0, BACKEND_OMP = 1, BACKEND_CUDA = 2 };
 extern int global_backend;
 /* Whether --backend was explicitly set by CLI. */

--- a/src/ModelData/Model_Data.hpp
+++ b/src/ModelData/Model_Data.hpp
@@ -232,6 +232,8 @@ public:
     const void *rhs_graph_dY = nullptr;
     void *rhs_graph_dYdot = nullptr;
     int rhs_graph_clamp_policy = 0;
+    int rhs_graph_deterministic_reduce = 0;
+    int rhs_graph_strict_fp = 0;
     unsigned int rhs_graph_kernel_nodes = 0;
     int rhs_graph_failed = 0;
     std::vector<double> d2h_QeleSurf_flat;


### PR DESCRIPTION
Closes #83\n\n## Summary\n- Add runtime env toggles (CUDA backend):\n  - SHUD_DETERMINISTIC_REDUCE=0/1 (default 1)\n  - SHUD_STRICT_FP=0/1 (forces deterministic reduce)\n- Add CUDA build switch: make shud_cuda STRICT_FP=1 (adds --fmad=false/--prec-div/--prec-sqrt + SHUD_STRICT_FP_BUILD)\n- Make CUDA Graph cache aware of clamp/deterministic/strict flags\n- Emit strict_fp/det_reduce in BENCH_STATS; bench script logs them\n- Docs: docs/cuda_strict_mode.md\n\n## Testing\n- Built: make shud, make shud_omp\n