### PR TITLE
[P3] PERF-MIXED-001 Mixed-precision CUDA preconditioner (fp32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ make shud_cuda CUDA_GENCODE='-gencode arch=compute_80,code=sm_80'
 - `--backend cpu|omp|cuda`: select runtime backend. Each binary has its own default: `shud`→cpu, `shud_omp`→omp, `shud_cuda`→cuda. Use this flag to override.
 - `--precond` / `--no-precond`: enable/disable CVODE preconditioner (CUDA backend only; default ON for `--backend cuda`)
   - Env override: `SHUD_CUDA_PRECOND=0/1/auto`
+  - Env: `SHUD_CUDA_PRECOND_FP=fp64|fp32` (experimental; mixed-precision precond). Details: `docs/cuda_mixed_precision.md`
 - CUDA perf/consistency knobs (env vars; CUDA backend only):
   - `SHUD_CUDA_GRAPH=0/1/auto` (+ `NY_CUDA_GRAPH_MAX` for auto threshold)
   - `SHUD_DETERMINISTIC_REDUCE=0/1`

--- a/docs/cuda_mixed_precision.md
+++ b/docs/cuda_mixed_precision.md
@@ -1,0 +1,38 @@
+# CUDA mixed-precision preconditioner (experimental)
+
+This repo supports an **experimental** mixed-precision mode for the CUDA CVODE preconditioner (Block-Jacobi).
+
+Goal: reduce preconditioner memory traffic and use faster fp32 math inside `PSolve`, while keeping the state vector and RHS in `realtype=double`.
+
+## Switch
+
+- `SHUD_CUDA_PRECOND_FP=fp64|fp32` (default: `fp64`)
+  - `fp64`: legacy behavior (store/apply preconditioner in double).
+  - `fp32`: store/apply preconditioner in float (mixed precision).
+
+Accepted aliases: `double`/`float`, `0`/`1`, `on`/`off`.
+
+## Notes / expected impact
+
+- Mixed precision can change GMRES/Newton convergence behavior (different solver path), even if RHS math is unchanged.
+- Always compare both **accuracy** and **CVODE stats** (`CVODE_STATS` line) when evaluating.
+
+## How to evaluate
+
+On a CUDA machine (with `shud_cuda` built):
+
+```bash
+# fp64 precond (baseline)
+SHUD_CUDA_PRECOND=1 SHUD_CUDA_PRECOND_FP=fp64 ./shud_cuda ccw
+
+# fp32 precond (mixed precision)
+SHUD_CUDA_PRECOND=1 SHUD_CUDA_PRECOND_FP=fp32 ./shud_cuda ccw
+
+python3 post_analysis/accuracy_comparison.py \
+  output/ccw_cpu output/ccw_cuda \
+  --tol_cuda 1e-3
+```
+
+If you need tighter reproducibility, consider combining with deterministic reductions / strict-fp build flags:
+- `docs/cuda_strict_mode.md`
+

--- a/src/GPU/DeviceContext.hpp
+++ b/src/GPU/DeviceContext.hpp
@@ -153,6 +153,7 @@ struct DeviceModel {
 
     /* Block-Jacobi preconditioner storage (PSetup/PSolve). */
     double *prec_inv = nullptr;
+    float *prec_inv_fp32 = nullptr;
 };
 
 #ifdef _CUDA_ON

--- a/src/Model/Macros.hpp
+++ b/src/Model/Macros.hpp
@@ -163,6 +163,10 @@ enum PrecondMode { PRECOND_MODE_OFF = 0, PRECOND_MODE_ON = 1, PRECOND_MODE_AUTO 
 extern int global_precond_mode;
 /* Resolved CVODE preconditioner enable flag (CUDA backend only). */
 extern int global_precond_enabled;
+/* Preconditioner internal precision (CUDA backend only).
+ * 0: fp64 (default), 1: fp32 (mixed precision).
+ */
+extern int global_precond_fp32;
 
 enum CudaGraphMode { CUDA_GRAPH_OFF = 0, CUDA_GRAPH_ON = 1, CUDA_GRAPH_AUTO = 2 };
 /* Requested CUDA Graph mode for RHS launches (CUDA backend only). */


### PR DESCRIPTION
Closes #87

## Summary
- Add experimental CUDA preconditioner fp32 mode via env: SHUD_CUDA_PRECOND_FP=fp64|fp32
- Store/apply Block-Jacobi preconditioner in fp32 when enabled; state/RHS remain realtype=double
- Extend CVODE_STATS + bench runner to record precond_fp
- Docs: docs/cuda_mixed_precision.md

## Testing
- Built: make shud, make shud_omp
